### PR TITLE
Update background colors to the ones found on the style guide

### DIFF
--- a/design/colors.less
+++ b/design/colors.less
@@ -1,9 +1,9 @@
-@font-color: #ffffff;
+@font-color: rgba(255, 255, 255, 0.8);
 @disabled-font-color: #8e8e8e;
 @accent-font-color: #eb7c09;
 
-@background-color: rgba( 0, 0, 0, 0.2 );
-@alternate-background-color: rgba( 255, 255, 255, 0.1 );
+@background-color: rgba( 0, 0, 0, 0.33 );
+@alternate-background-color: rgba( 255, 255, 255, 0.33 );
 
 @high-end-rarity-color: #efb223;
 @high-end-accent-font-color: #f8db97;

--- a/design/colors.less
+++ b/design/colors.less
@@ -1,4 +1,4 @@
-@font-color: rgba(255, 255, 255, 0.8);
+@font-color: #ffffff;
 @disabled-font-color: #8e8e8e;
 @accent-font-color: #eb7c09;
 


### PR DESCRIPTION
The official-ish (leaked) style guide, from when it was in Alpha, found here: https://imgur.com/gallery/Y2HV1 has a lot of color values used in the UI that made it to the final version seen in the current game. 

There's two commits because I forgot I had changed the text color when I did not intend on changing it for the PR. 